### PR TITLE
Bug/make conversation active on notification click

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ androidMessagesWebview.addEventListener('did-start-loading', () => {
        * TODO: Provide visual indicators for Linux, could set window (taskbar) icon, may also do for Windows
        */
 
-      return callback(false); // Prevent the webview's notification from coming through (we roll our own)
+      return callback(true); // Prevent the webview's notification from coming through (we roll our own)
     }
 
     if (!url.startsWith('https://messages.android.com')) {

--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ androidMessagesWebview.addEventListener('did-start-loading', () => {
        * TODO: Provide visual indicators for Linux, could set window (taskbar) icon, may also do for Windows
        */
 
-      return callback(true); // Prevent the webview's notification from coming through (we roll our own)
+      return callback(false); // Prevent the webview's notification from coming through (we roll our own)
     }
 
     if (!url.startsWith('https://messages.android.com')) {

--- a/src/background.js
+++ b/src/background.js
@@ -161,11 +161,31 @@ if (isSecondInstance) {
 
         trayManager.toggleOverlay(true);
 
-        customNotification.once('click', () => {
-          mainWindow.show();
-        });
+        // customNotification.once('click', () => {
+        //   mainWindow.show();
+        //   // event.sender.session.setPermissionRequestHandler((webContents, permission, callback) => {
+        //   //   const url = webContents.getURL();
 
-        customNotification.show();
+        //   //   if (permission === 'notifications') {
+        //   //     /*
+        //   //      * We always get a "notification" when the app starts due to calling setPermissionRequestHandler,
+        //   //      * which accepts the permission to send browser notifications on behalf of the user.
+        //   //      * This "notification" should fire before we start listening for notifications,
+        //   //      * and should not cause problems.
+        //   //      * TODO: Move this to a helper
+        //   //      * TODO: Provide visual indicators for Linux, could set window (taskbar) icon, may also do for Windows
+        //   //      */
+
+        //   //     return callback(false); // Prevent the webview's notification from coming through (we roll our own)
+        //   //   }
+
+        //   //   if (!url.startsWith('https://messages.android.com')) {
+        //   //     return callback(false); // Deny
+        //   //   }
+        //   // });
+        // });
+
+        //customNotification.show();
       }
     });
 

--- a/src/background.js
+++ b/src/background.js
@@ -165,6 +165,8 @@ if (isSecondInstance) {
           mainWindow.show();
         });
 
+        // Allows us to marry our custom notification and its behavior with the helpful behavior
+        // (conversation highlighting) that Google provides. See the webview bridge for details.
         global.currentNotification = customNotification;
         event.sender.send(EVENT_NOTIFICATION_REFLECT_READY, true);
 

--- a/src/background.js
+++ b/src/background.js
@@ -14,7 +14,7 @@ import { helpMenuTemplate } from './menu/help_menu_template';
 import createWindow from './helpers/window';
 import TrayManager from './helpers/tray/tray_manager';
 import settings from 'electron-settings';
-import { IS_MAC, IS_WINDOWS, IS_LINUX, IS_DEV, SETTING_TRAY_ENABLED, EVENT_WEBVIEW_NOTIFICATION } from './constants';
+import { IS_MAC, IS_WINDOWS, IS_LINUX, IS_DEV, SETTING_TRAY_ENABLED, EVENT_WEBVIEW_NOTIFICATION, EVENT_NOTIFICATION_REFLECT_READY } from './constants';
 
 // Special module holding environment variables which you declared
 // in config/env_xxx.json file.
@@ -161,31 +161,14 @@ if (isSecondInstance) {
 
         trayManager.toggleOverlay(true);
 
-        // customNotification.once('click', () => {
-        //   mainWindow.show();
-        //   // event.sender.session.setPermissionRequestHandler((webContents, permission, callback) => {
-        //   //   const url = webContents.getURL();
+        customNotification.once('click', () => {
+          mainWindow.show();
+        });
 
-        //   //   if (permission === 'notifications') {
-        //   //     /*
-        //   //      * We always get a "notification" when the app starts due to calling setPermissionRequestHandler,
-        //   //      * which accepts the permission to send browser notifications on behalf of the user.
-        //   //      * This "notification" should fire before we start listening for notifications,
-        //   //      * and should not cause problems.
-        //   //      * TODO: Move this to a helper
-        //   //      * TODO: Provide visual indicators for Linux, could set window (taskbar) icon, may also do for Windows
-        //   //      */
+        global.currentNotification = customNotification;
+        event.sender.send(EVENT_NOTIFICATION_REFLECT_READY, true);
 
-        //   //     return callback(false); // Prevent the webview's notification from coming through (we roll our own)
-        //   //   }
-
-        //   //   if (!url.startsWith('https://messages.android.com')) {
-        //   //     return callback(false); // Deny
-        //   //   }
-        //   // });
-        // });
-
-        //customNotification.show();
+        customNotification.show();
       }
     });
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -21,6 +21,7 @@ const SETTING_TRAY_ENABLED = 'trayEnabledPref';
 
 // Events
 const EVENT_WEBVIEW_NOTIFICATION = 'messages-webview-notification';
+const EVENT_NOTIFICATION_REFLECT_READY = 'messages-webview-reflect-ready';
 
 export {
     osName,
@@ -30,5 +31,6 @@ export {
     IS_LINUX,
     IS_DEV,
     SETTING_TRAY_ENABLED,
-    EVENT_WEBVIEW_NOTIFICATION
+    EVENT_WEBVIEW_NOTIFICATION,
+    EVENT_NOTIFICATION_REFLECT_READY
 };

--- a/src/helpers/tray/tray_manager.js
+++ b/src/helpers/tray/tray_manager.js
@@ -57,6 +57,7 @@ export default class TrayManager {
     } else {
         // Mac tray icon filename MUST end in 'Template' and contain only black and transparent pixels.
         // Otherwise, automatic inversion and dark mode appearance won't work.
+        // See: https://stackoverflow.com/questions/41664208/electron-tray-icon-change
         const trayIconFileName = IS_MAC ? 'icon_macTemplate.png' : 'icon.png';
         return path.join(__dirname, '..', 'resources', 'tray', trayIconFileName);
     }

--- a/src/helpers/webview/bridge.js
+++ b/src/helpers/webview/bridge.js
@@ -2,8 +2,8 @@
 // Newer ES6 features (import/export syntax etc...) are not allowed here nor in any JS which this imports.
 
 const popupContextMenu = require('./context_menu.js');
-const { EVENT_WEBVIEW_NOTIFICATION } = require('../../constants');
-const ipc = require('electron').ipcRenderer;
+const { EVENT_WEBVIEW_NOTIFICATION, EVENT_NOTIFICATION_REFLECT_READY } = require('../../constants');
+const { ipcRenderer, remote } = require('electron')
 
 // Electron (or the build of Chromium it uses?) does not seem to have any default right-click menu, this adds our own.
 window.addEventListener('contextmenu', popupContextMenu);
@@ -14,16 +14,29 @@ const OriginalBrowserNotification = Notification;
 // Necessary to generate and send a custom notification via Electron instead of just forwarding the webview one.
 Notification = function (title, options) {
     let notificationToSend = new OriginalBrowserNotification(title, options); // Still send the webview notification event so the ipc event fires
-    ipc.send(EVENT_WEBVIEW_NOTIFICATION, {
-        title,
-        options
-    });
+
+    let originalClickListener = null;
 
     const originalAddEventListener = notificationToSend.addEventListener;
     notificationToSend.addEventListener = function (type, listener, options) {
-        console.log('calling addEventListener', type, listener, options);
-        originalAddEventListener.call(notificationToSend, type, listener, options);
+        if (type === 'click') {
+            originalClickListener = listener;
+        } else {
+            originalAddEventListener.call(notificationToSend, type, listener, options);
+        }
     }
+
+    ipcRenderer.once(EVENT_NOTIFICATION_REFLECT_READY, (event, arg) => {
+        let theHookedUpNotification = remote.getGlobal('currentNotification');
+        if (typeof theHookedUpNotification === 'object' && typeof originalClickListener === 'function') {
+            theHookedUpNotification.once('click', originalClickListener);
+        }
+    });
+
+    ipcRenderer.send(EVENT_WEBVIEW_NOTIFICATION, {
+        title,
+        options
+    });
 
     return notificationToSend;
 };

--- a/src/helpers/webview/bridge.js
+++ b/src/helpers/webview/bridge.js
@@ -10,8 +10,17 @@ window.addEventListener('contextmenu', popupContextMenu);
 
 const OriginalBrowserNotification = Notification;
 
-// Override the webview's window's instance of the Notification class and forward them to the main process
-// Necessary to generate and send a custom notification via Electron instead of just forwarding the webview (Google) ones.
+/*
+ * Override the webview's window's instance of the Notification class and forward their data to the
+ * main process. This is Necessary to generate and send a custom notification via Electron instead
+ * of just forwarding the webview (Google) ones.
+ *
+ * Derived from:
+ * https://github.com/electron/electron/blob/master/docs/api/ipc-main.md#sending-messages
+ * https://stackoverflow.com/questions/2891096/addeventlistener-using-apply
+ * https://stackoverflow.com/questions/31231622/event-listener-for-web-notification
+ * https://stackoverflow.com/questions/1421257/intercept-javascript-event
+ */
 Notification = function (title, options) {
     let notificationToSend = new OriginalBrowserNotification(title, options); // Still send the webview notification event so the rest of this code runs (and the ipc event fires)
 


### PR DESCRIPTION
I accidentally broke active conversation highlighting when overriding the default notifications in order to make the app window appear when a notification is clicked. This fixes that, and overhauls the way that notification data and events are communicated between the webview and main process.