### PR TITLE
Hidden titlebar/Integrated traffic light on MacOS

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -10,7 +10,7 @@
     <webview id="androidMessagesWebview" src="https://messages.android.com/" autosize preload="bridge.js"></webview>
     
     <!--Enable dragging on the titlebar-->
-    <div class="titlebar"></div>
+    <div id="titlebar"></div>
     <div id="loader"></div>
   </div>
 

--- a/app/app.html
+++ b/app/app.html
@@ -8,8 +8,21 @@
   <div id="app">
     <!-- <webview id="androidMessagesWebview" src="https://davidwalsh.name/demo/notifications-api.php" autosize></webview> -->
     <webview id="androidMessagesWebview" src="https://messages.android.com/" autosize preload="bridge.js"></webview>
+    
+    <!--Enable dragging on the titlebar-->
+    <div class="titlebar"></div>
     <div id="loader"></div>
   </div>
+
+  <!--Making the title centered so that it won't get weirdly covered by 
+      the traffic light-->
+  <script>
+    var webview = document.getElementById('androidMessagesWebview');
+    webview.addEventListener('dom-ready', function () {
+        webview.insertCSS('div.kegSbc{width:100%}h1.tuQbQc{text-align:center}')
+    });
+  </script>
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/src/background.js
+++ b/src/background.js
@@ -105,7 +105,8 @@ if (isSecondInstance) {
       width: 1100,
       height: 800,
       autoHideMenuBar: autoHideMenuBar,
-      show: !(startInTray) //Starts in tray if set
+      show: !(startInTray),  //Starts in tray if set
+      titleBarStyle: IS_MAC ? 'hiddenInset' : '' //Turn on hidden frame on a Mac
     };
 
     if (IS_LINUX) {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -47,3 +47,13 @@ a {
   opacity: 0;
   pointer-events: none;
 }
+
+#titlebar {
+  -webkit-app-region: drag; 
+  position: fixed; 
+  width: 100%; 
+  height: 64px; 
+  top: 0; 
+  left: 0; 
+  background: none; 
+}


### PR DESCRIPTION
The default titlebar looks pretty bad on MacOS, so here's my take on it. 

![screenshot 2018-11-03 at 10 46 37 pm](https://user-images.githubusercontent.com/21138016/47953565-708d0000-dfba-11e8-8f59-e6b02ae9c9a9.png)

This may look weird on any platform other than the MacOS, though. 