### PR TITLE
android messages url change patch

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -7,7 +7,7 @@
 <body>
   <div id="app">
     <!-- <webview id="androidMessagesWebview" src="https://davidwalsh.name/demo/notifications-api.php" autosize></webview> -->
-    <webview id="androidMessagesWebview" src="http://messages.google.com/web" autosize preload="bridge.js"></webview>
+    <webview id="androidMessagesWebview" src="https://messages.google.com/web" autosize preload="bridge.js"></webview>
     
     <!--Enable dragging on the titlebar-->
     <div id="titlebar"></div>

--- a/app/app.html
+++ b/app/app.html
@@ -7,7 +7,7 @@
 <body>
   <div id="app">
     <!-- <webview id="androidMessagesWebview" src="https://davidwalsh.name/demo/notifications-api.php" autosize></webview> -->
-    <webview id="androidMessagesWebview" src="https://messages.android.com/" autosize preload="bridge.js"></webview>
+    <webview id="androidMessagesWebview" src="http://messages.google.com/web" autosize preload="bridge.js"></webview>
     
     <!--Enable dragging on the titlebar-->
     <div id="titlebar"></div>


### PR DESCRIPTION
the url for the platform has changed to messages.google.com/web. the app has stopped functioning as a result