### PR TITLE
Add cmd+w shortcut for hiding window

### DIFF
--- a/src/menu/app_menu_template.js
+++ b/src/menu/app_menu_template.js
@@ -15,7 +15,7 @@ export const appMenuTemplate = {
         settingsMenu,
         {
             type: 'separator'
-        },        
+        },
         {
             label: 'Hide Android Messages Desktop',
             accelerator: 'Command+H',
@@ -23,6 +23,11 @@ export const appMenuTemplate = {
         },
         {
             type: 'separator',
+        },
+        {
+            label: 'Close',
+            accelerator: 'Command+W',
+            click: () => app.hide()
         },
         {
             label: 'Quit',


### PR DESCRIPTION
Fixes https://github.com/chrisknepper/android-messages-desktop/issues/214 https://github.com/chrisknepper/android-messages-desktop/issues/8

`app.hide()` seemed like the best option here, but let me know if something else would be more ideal, I looked through here https://electronjs.org/docs/api/app a bit.